### PR TITLE
handle extra hex string in syslog output

### DIFF
--- a/followdns
+++ b/followdns
@@ -20,7 +20,7 @@ unless ( -d "$repo" ) { die "No such directory $repo, $!"; }
 while (defined(my $line = $log->read)) {
     my ($client, $key, $zone, $change);
 
-    if ( $line =~ m{named\[\d+\]: client (\S+?)/key ([^:]+): updating zone '(.+?)/IN': (.+)} ) {
+    if ( $line =~ m{named\[\d+\]: client (?:\@0x\S+ )?(\S+?)/key ([^:]+): updating zone '(.+?)/IN': (.+)} ) {
       $client="$1";
       $key="$2";
       $zone="$3";


### PR DESCRIPTION
This appeared after upgrade to Ubuntu 18.04, with BIND 9.11.  I have no
idea what it means, so I just ignore it.  Example:

  named[1047]: client @0x7f01600e49d0 2a02:c0:2:7::62#51580/key kjetilho.user: updating zone 'example.com/IN': delete all rrsets from name 'test-kjetilho.example.com'